### PR TITLE
Accept parameters in scriptContent raw string

### DIFF
--- a/command/install.go
+++ b/command/install.go
@@ -27,7 +27,7 @@ const (
 	scheduleCommand  = "schedule"
 	terminateCommand = "terminate"
 	scriptContent    = `#!/bin/bash
-%s %s >> %s/chaosmonkey-%s.log 2>&1
+%s %s "$@" >> %s/chaosmonkey-%s.log 2>&1
 `
 )
 


### PR DESCRIPTION
The documentation shows `chaosmonkey-terminate.sh` accepting parameters - https://netflix.github.io/chaosmonkey/How-to-deploy/#create-appschaosmonkeychaosmonkey-terminatesh

The `chaosmonkey-terminate.sh` generated by `chaosmonkey install` does not accept arguments as shown in the documentation. This prevents the `chaosmonkey-daily-terminations` cron job from working as written as the arguments to `chaosmonkey terminate` are not accepted.

This PR adds accepting parameters to both the `chaosmonkey-terminate.sh` and `chaosmonkey-schedule.sh` scripts generated by the install command.